### PR TITLE
Fix code scanning alert no. 1: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/src/Application/src/RazorPagesTestSample/Pages/Index.cshtml.cs
+++ b/src/Application/src/RazorPagesTestSample/Pages/Index.cshtml.cs
@@ -94,7 +94,12 @@ namespace RazorPagesTestSample.Pages
 
         public static void WriteToDirectory(ZipArchiveEntry entry, string destDirectory)
         {
-            string destFileName = Path.Combine(destDirectory, entry.FullName);
+            string destFileName = Path.GetFullPath(Path.Combine(destDirectory, entry.FullName));
+            string fullDestDirPath = Path.GetFullPath(destDirectory + Path.DirectorySeparatorChar);
+            if (!destFileName.StartsWith(fullDestDirPath))
+            {
+                throw new InvalidOperationException("Entry is outside the target dir: " + destFileName);
+            }
             entry.ExtractToFile(destFileName);
         }
     }


### PR DESCRIPTION
Fixes [https://github.com/midcapwarrior/KW_TechExcel-Accelerate-developer-productivity-with-GitHub-Copilot-and-Dev-Box/security/code-scanning/1](https://github.com/midcapwarrior/KW_TechExcel-Accelerate-developer-productivity-with-GitHub-Copilot-and-Dev-Box/security/code-scanning/1)

To fix the problem, we need to ensure that the file paths extracted from the zip archive are validated to prevent directory traversal attacks. This involves:
1. Using `Path.GetFullPath` to resolve any directory traversal elements in the combined path.
2. Ensuring that the resolved path is within the intended destination directory.

The best way to fix this without changing existing functionality is to:
- Resolve the full path of the destination file using `Path.GetFullPath`.
- Resolve the full path of the destination directory.
- Check that the resolved file path starts with the resolved directory path.
- Throw an exception if the check fails.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
